### PR TITLE
WIP: Use strict comparison operators

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,9 +7,11 @@ class Config
     public static function create() : \PhpCsFixer\ConfigInterface
     {
         return \PhpCsFixer\Config::create()
+        ->setRiskyAllowed(true)
         ->setRules([
             '@PSR2' => true,
             'array_syntax' => ['syntax' => 'short'],
+            'strict_comparison' => true,
         ]);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -62,4 +62,10 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectFailure("<?php function a_b() {\n}\n");
     }
+
+    public function testStrictComparison()
+    {
+        $this->expectSuccess("<?php \$a === \$b;\n");
+        $this->expectFailure("<?php \$a == \$b;\n");
+    }
 }


### PR DESCRIPTION
This uses a "risky" fixer. php-cs-fixer calls a fixer "risky" when running `php-cs-fixer fix` can change the behaviour of the code.

Setting risky to `true` in the config might not be the best approach. I wonder if we can warn and require an extra argument (`--risky=yes`) when running `php-cs-fixer fix` but not warn when running `php-cs-fixer fix --diff`.

If we already had this config in a project, and we ran `php-cs-fixer fix` after this feature was added, then it would change the behaviour. We probably don't want that, but we would like to produce a warning whenever `==` is used.