### PR TITLE
Feature/php8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.2', '7.4']
+        php-versions: ['7.4', '8.1']
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-07-28
+
+### Added
+- Support for PHP 8.1 and up
+
+### Removed
+- Support for PHP 7.2 and 7.3
+
 ## [2.0.0] - 2021-10-08
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         }
     },
     "require": {
-        "php": "^7.2||^8.1",
+        "php": "^7.4||^8.1",
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2||^8.1",
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
This PR:

- Removes support for PHP versions below 7.4 (7.4 is the minimum we run)
- Adds support for PHP 8.1 and above
- Runs CI in 7.4 and 8.1
- Bumps the version number to 2.0.1