### PR TITLE
Feature/psr 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- PSR-2 (deprecated) replaced by PSR-12
+
+### Added
+- Enforcing tabs for indentation
+
 ## [2.0.1] - 2022-07-28
 
 ### Added

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,7 +8,7 @@ class Config
     {
         $config = new \PhpCsFixer\Config();
         return $config->setRules([
-            '@PSR2' => true,
+            '@PSR12' => true,
             'array_syntax' => ['syntax' => 'short']
         ])
         ->setIndent("\t");

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,13 +4,13 @@ namespace Dxw\PhpCsFixerConfig;
 
 class Config
 {
-    public static function create() : \PhpCsFixer\ConfigInterface
-    {
-        $config = new \PhpCsFixer\Config();
-        return $config->setRules([
-            '@PSR12' => true,
-            'array_syntax' => ['syntax' => 'short']
-        ])
-        ->setIndent("\t");
-    }
+	public static function create(): \PhpCsFixer\ConfigInterface
+	{
+		$config = new \PhpCsFixer\Config();
+		return $config->setRules([
+			'@PSR12' => true,
+			'array_syntax' => ['syntax' => 'short']
+		])
+		->setIndent("\t");
+	}
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,7 +9,8 @@ class Config
         $config = new \PhpCsFixer\Config();
         return $config->setRules([
             '@PSR2' => true,
-            'array_syntax' => ['syntax' => 'short'],
-        ]);
+            'array_syntax' => ['syntax' => 'short']
+        ])
+        ->setIndent("\t");
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -54,7 +54,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 	public function testLongArray()
 	{
 		$this->expectFailure("<?php \$a = array();\n");
-		$this->expectSuccess("<?php \$a = [];\n");
+		$this->expectSuccess("<?php\n\n\$a = [];\n");
 	}
 
 	// PSR2

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -4,62 +4,62 @@ namespace Dxw\PhpCsFixerConfig;
 
 class ConfigTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp() : void
-    {
-        $this->dir = __DIR__.'/test-dir';
-        $this->file = $this->dir.'/test.php';
-    }
+	public function setUp(): void
+	{
+		$this->dir = __DIR__.'/test-dir';
+		$this->file = $this->dir.'/test.php';
+	}
 
-    public function rmDir()
-    {
-        exec("rm -rf {$this->dir}");
-    }
+	public function rmDir()
+	{
+		exec("rm -rf {$this->dir}");
+	}
 
-    public function runPhpCsFixer(string $code, bool $expectZero)
-    {
-        $this->rmDir();
-        mkdir($this->dir);
-        file_put_contents($this->dir.'/.php-cs-fixer.php', '<?php $finder = \PhpCsFixer\Finder::create()->in(__DIR__); return \Dxw\PhpCsFixerConfig\Config::create()->setFinder($finder);');
-        file_put_contents($this->file, $code);
-        exec("sh -c 'cd {$this->dir} && ../../vendor/bin/php-cs-fixer fix --dry-run --diff 2>&1'", $output, $exitStatus);
-        $stringOutput = sprintf("Input:\n%s\nOutput:\n%s\n", $code, implode("\n", $output));
-        if ($expectZero) {
-            $this->assertEquals($exitStatus, 0, $stringOutput);
-        } else {
-            $this->assertNotEquals($exitStatus, 0, $stringOutput);
-        }
-    }
+	public function runPhpCsFixer(string $code, bool $expectZero)
+	{
+		$this->rmDir();
+		mkdir($this->dir);
+		file_put_contents($this->dir.'/.php-cs-fixer.php', '<?php $finder = \PhpCsFixer\Finder::create()->in(__DIR__); return \Dxw\PhpCsFixerConfig\Config::create()->setFinder($finder);');
+		file_put_contents($this->file, $code);
+		exec("sh -c 'cd {$this->dir} && ../../vendor/bin/php-cs-fixer fix --dry-run --diff 2>&1'", $output, $exitStatus);
+		$stringOutput = sprintf("Input:\n%s\nOutput:\n%s\n", $code, implode("\n", $output));
+		if ($expectZero) {
+			$this->assertEquals($exitStatus, 0, $stringOutput);
+		} else {
+			$this->assertNotEquals($exitStatus, 0, $stringOutput);
+		}
+	}
 
-    public function expectFailure(string $code)
-    {
-        $this->runPhpCsFixer($code, false);
-    }
+	public function expectFailure(string $code)
+	{
+		$this->runPhpCsFixer($code, false);
+	}
 
-    public function expectSuccess(string $code)
-    {
-        $this->runPhpCsFixer($code, true);
-    }
+	public function expectSuccess(string $code)
+	{
+		$this->runPhpCsFixer($code, true);
+	}
 
-    public function tearDown() : void
-    {
-        $this->rmDir();
-    }
+	public function tearDown(): void
+	{
+		$this->rmDir();
+	}
 
-    public function testEmptyFile()
-    {
-        $this->expectSuccess("<?php");
-        $this->expectSuccess("<?php\n");
-    }
+	public function testEmptyFile()
+	{
+		$this->expectSuccess("<?php");
+		$this->expectSuccess("<?php\n");
+	}
 
-    public function testLongArray()
-    {
-        $this->expectFailure("<?php \$a = array();\n");
-        $this->expectSuccess("<?php \$a = [];\n");
-    }
+	public function testLongArray()
+	{
+		$this->expectFailure("<?php \$a = array();\n");
+		$this->expectSuccess("<?php \$a = [];\n");
+	}
 
-    // PSR2
-    public function testSnakeCaseFunctions()
-    {
-        $this->expectFailure("<?php function a_b() {\n}\n");
-    }
+	// PSR2
+	public function testSnakeCaseFunctions()
+	{
+		$this->expectFailure("<?php function a_b() {\n}\n");
+	}
 }


### PR DESCRIPTION
This PR:

- Replaces the `PSR-2` standard with `PSR-12`. `PSR-12` has replaced `PSR-2` (now deprecated): https://www.php-fig.org/psr/psr-12/
- Enforces tabs for indentation, as this is more accessible and allows for easier customisation of dev environments
- Applies those config changes to the code in this repo