### PR TITLE
Upgrade Psalm and PHPUnit to PHP 8.2 friendly versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.4', '8.1']
+        php-versions: ['7.4', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Psalm and PHPUnit updated to allow for PHP 8.2 support
+
 ## [2.1.0] - 2022-09-26
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "require-dev": {
-        "vimeo/psalm": "^4.10",
-        "phpunit/phpunit": "^8.5"
+        "vimeo/psalm": "^5.15",
+        "phpunit/phpunit": "^9.0"
     }
 }


### PR DESCRIPTION
This PR updates the dependencies to PHP 8.2-friendly versions, and runs CI in 8.2 to confirm.